### PR TITLE
Screener fix

### DIFF
--- a/client.go
+++ b/client.go
@@ -86,10 +86,10 @@ func (c *client) doTimeoutRequest(timer *time.Timer, req *http.Request) (*http.R
 }
 
 // do prepare and process HTTP request to TradingView Scanner API
-func (c *client) do(method string, payload string, authNeeded bool) (response []byte, err error) {
+func (c *client) do(method string, sreener string, payload string, authNeeded bool) (response []byte, err error) {
 	connectTimer := time.NewTimer(c.httpTimeout)
 
-	rawurl := fmt.Sprintf("%s%s/%s", API_URL, DEFAULT_SCREENER, API_POSTFIX)
+	rawurl := fmt.Sprintf("%s%s/%s", API_URL, screener, API_POSTFIX)
 
 	if c.debug {
 		fmt.Println("url: ", rawurl)

--- a/scanner.go
+++ b/scanner.go
@@ -169,7 +169,7 @@ func (c *Scanner) GetRecommendations(screener, exchange, symbol, interval string
 		ContextLogger.Error(err, exchange, symbol)
 		return RecommendSummary{}, err
 	}
-	r, err := c.client.do("POST", string(payload), false)
+	r, err := c.client.do("POST", screener, string(payload), false)
 	if err != nil {
 		ContextLogger.Errorf("Exchange (%s) or symbol (%s) not found %v", exchange, symbol, err)
 		return RecommendSummary{}, err
@@ -204,7 +204,7 @@ func (c *Scanner) GetIchimoku(screener, exchange, symbol, interval string) (Ichi
 		ContextLogger.Error(err, exchange, symbol)
 		return Ichimoku, value, err
 	}
-	r, err := c.client.do("POST", string(payload), false)
+	r, err := c.client.do("POST", screener, string(payload), false)
 	if err != nil {
 		ContextLogger.Errorf("Exchange (%s) or symbol (%s) not found %v", exchange, symbol, err)
 		return Ichimoku, value, err
@@ -232,13 +232,19 @@ func (c *Scanner) GetAnalysis(screener, exchange, symbol, interval string) (Reco
 		ContextLogger.Error(err, exchange, symbol)
 		return RecommendSummary{}, err
 	}
-	r, err := c.client.do("POST", string(payload), false)
+	r, err := c.client.do("POST", screener, string(payload), false)
 	if err != nil {
 		ContextLogger.Errorf("Exchange (%s) or symbol (%s) not found %v", exchange, symbol, err)
 		return RecommendSummary{}, err
 	}
 	err = json.Unmarshal(r, &c.data)
 	if err != nil {
+		ContextLogger.Error(err)
+		return RecommendSummary{}, err
+	}
+
+	if c.data.TotalCount <= 0 {
+		err = fmt.Errorf("No data available to analyze")
 		ContextLogger.Error(err)
 		return RecommendSummary{}, err
 	}


### PR DESCRIPTION
* Fixes the requests code to use the passed in screener instead of always using the default crypto screener.
* Adds error handling when there is no screener data to parse (i.e. a request was made to the wrong screener) - prevents panic as identified in #1 